### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/0x5b62656e5d/zephybot/security/code-scanning/1](https://github.com/0x5b62656e5d/zephybot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow does not inherit unnecessary write permissions from the repository or organization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
